### PR TITLE
Fix jar path detection to allow spaces and other special characters

### DIFF
--- a/src/main/java/ovs/Global.java
+++ b/src/main/java/ovs/Global.java
@@ -5,6 +5,7 @@ import ovs.graph.node.Node;
 import ovs.graph.node.interfaces.NodeDisabled;
 
 import java.io.*;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.*;
 import java.util.jar.JarEntry;
@@ -435,7 +436,7 @@ public class Global {
         JarFile jf = null;
         try{
             ArrayList<String> paths = new ArrayList<>();
-            String s = new File(Global.class.getResource("").getPath()).getParent().replaceAll("(!|file:\\\\)", "");
+            String s = new File(Global.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getPath();
             jf = new JarFile(s);
             Enumeration<JarEntry> entries = jf.entries();
 
@@ -449,7 +450,9 @@ public class Global {
             return paths;
         }catch (IOException e) {
 //            e.printStackTrace();
-        }finally {
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        } finally {
             if(jf != null) {
                 try {
                     jf.close();


### PR DESCRIPTION
I found a bug in the current code for getting the current path of the running jar file to load the nodes from. If the path had spaces (and probably other special characters), they would be substituted for %20 as in URL encoding and finding the jar file would fail. This pull request changes the method for retrieving the path of the jar file to a more reliable one that can properly handle spaces.

I should also note that to get the code to compile, I had to change version "3.3.2-SNAPSOT" of lwjgl-bom in the pom.xml to "3.3.2", however I did not include this change in the PR because I'm not too experienced using Maven and this might only be an issue on my end.

I apologize if I've made a mistake, this is my first time contributing on GitHub. Thanks :)